### PR TITLE
docs: 9장 이상호 정리글 업로드

### DIFF
--- a/이상호/chapter9/9장 연산자 오버로딩과 다른 관례.md
+++ b/이상호/chapter9/9장 연산자 오버로딩과 다른 관례.md
@@ -1,0 +1,695 @@
+# 9장 연산자 오버로딩과 다른 관례
+
+## 9.1 산술 연산자를 오버로드해서 임의의 클래스에 대한 연산을 더 편리하게 만들기
+
+- Kotlin 에서 규칙을 사용하는 가장 간단한 예는 산술 연산자
+- Java 에서는 전체 산술 연산자 집합을 기본유형에만 사용할 수 있으며, 추가로 `+` 연산자를 문자열값에 사용
+- 하지만 이러한 연산은 다른 경우에도 편리
+  - 예를 들어 `BigInteger` 클래스를 통해 숫자로 작업하는 경우 `add` 메서드를 명시적으로 호출하는 것보다 `+` 를 사용하여 합산하는 것이 더 좋음
+
+### 9.1.1 plus, times, divide 등: 이항 산술 연산 오버로딩
+
+- 이 연산은 점의 x 좌표와 y 좌표를 합산한다.
+
+```kotlin
+data class Point(val x: Int, val y: Int) {
+    operator fun plus(other: Point): Point {
+		return Point(x + other.x, y + other.y)
+	} 
+}
+
+fun main() {
+    val p1 = Point(10, 20)
+    val p2 = Point(30, 40)
+    println(p1 + p2)
+    // Point(x=40, y=60)
+}
+```
+
+- Kotlin 에는 오버로드할 수 있는 연산자 집합이 제한되어 있으며, 각 연산자는 클래스에서 정의해야 하는 함수의 이름에 해당한다. 
+- 아래 표에는 정의할 수 있는 모든 이진 연산자와 해당 함수 이름이 나열되어 있다.
+
+|식|함수 이름|
+|-|-------|
+|a * b|times|
+|a / b|div|
+|a % b|mod|
+|a + b|plus|
+|a - b|minus|
+
+- 연산자를 정의할 때 두 연산자에 동일한 유형을 사용할 필요는 없다. 예를 들어, 소수점 단위로 점의 크기를 조정할 수 있는 연산자를 정의해 보겠다.
+
+```kotlin
+operator fun Point.times(scale: Double): Point {
+    return Point((x * scale).toInt(), (y * scale).toInt())
+}
+fun main() {
+    val p = Point(10, 20)
+    println(p * 1.5)
+    // Point(x=15, y=30)
+}
+```
+
+### 9.1.2 연산을 적용한 다음에 그 결과를 바로 대입: 복합 대입 연산자 오버로딩
+
+- 일반적으로 +와 같은 연산자를 정의할 때 Kotlin은 + 연산뿐만 아니라 +=도 지원한다. +=, -= 등과 같은 연산자를 복합 할당 연산자라고 한다.
+
+```kotlin
+fun main() {
+	var point = Point(1, 2) 
+    point += Point(3, 4)	 
+    println(point)
+	// Point(x=4, y=6)
+}
+```
+
+- Kotlin 표준 라이브러리에는 변경 가능한 컬렉션에 plusAssign 함수가 정의되어 있으며, 이를 오버로딩하여 사용한다.
+
+```kotlin
+operator fun <T> MutableCollection<T>.plusAssign(element: T) {
+    this.add(element)
+}
+```
+
+- mutable 콜렉션의 경우 기존의 콜렉션에 요소를 더하는 반면, immutable 한 콜렉션의 경우 새로운 객체를 반환한다.
+
+```kotlin
+fun main() {
+	val list = mutableListOf(1, 2)
+	list += 3                           // +=는 list를 변경
+	val newList = list + listOf(4, 5) // +는 두 리스트의 모든 원소를 포함하는 새로운 리스트를 반환
+	println(list)
+	// [1, 2, 3]
+	println(newList)
+	// [1, 2, 3, 4, 5]
+}
+```
+
+### 9.1.3 피연산자가 1개뿐인 연산자: 단항 연산자 오버로딩
+
+- 단항 연산자를 오버로드
+
+```kotlin
+operator fun Point.unaryMinus(): Point { // 단항 minus(부호 반전) 함수는 파라미터가 없음
+    return Point(-x, -y) // 좌표에서 각 성분의 음수를 취한 새 점을 반환
+}
+fun main() {
+    val p = Point(10, 20)
+    println(-p)
+    // Point(x=-10, y=-20)
+}
+```
+
+| 식        | 함수 이름      |
+|----------|------------|
+| +a       | unaryPlus  |
+| -a       | unaryMinus |
+| !a       | not        |
+| ++a, a++ | inc        |
+| --a, a-- | dec        |
+
+## 9.2 비교 연산자를 오버로딩해서 객체들 사이의 관계를 쉽게 검사
+
+- 산술 연산자와 마찬가지로 Kotlin 에서는 기본 유형뿐만 아니라 모든 객체에 비교 연산자 (==, !=, >, < 등)를 사용할 수 있다.
+
+### 9.2.1 동등성 연산자: equals
+
+- Kotlin 에서 == 연산자를 사용하면 equals 메서드의 호출로 변환되는 것을 보았다. 
+- nullable 하여도 널처리가 들어갈 뿐 equals 를 호출하는 것은 동일하다.
+
+```kotlin
+class Point(val x: Int, val y: Int) {
+    override fun equals(other: Any?): Boolean { // Any 에 정의된 메서드를 오버라이드
+        if (other === this) return true         // 최적화: 파라미터가 이 식의 this 와 같은 객체인지 살펴봄
+        if (other !is Point) return false       // 파라미터 타입을 검사
+        return other.x == x && other.y == y     // Point 로 스마트 캐스트해서 x와 y 프로퍼티에 접근
+	} 
+}
+
+fun main() {
+    println(Point(10, 20) == Point(10, 20))
+    // true
+    println(Point(10, 20) != Point(5, 5))
+    // true
+    println(null == Point(1, 2))
+    // false
+}
+```
+
+### 9.2.2 순서 연산자: compareTo (〈, 〉, 〈=, 〉=)
+
+- Java 에서 클래스는 최대값 찾기나 정렬과 같이 값을 비교하는 알고리즘에 사용하기 위해 Comparable 인터페이스를 구현 가능
+- Kotlin 은 동일한 Comparable 인터페이스를 지원 
+- 아래 그림같이 해당 인터페이스에 정의된 compareTo 메서드를 규칙에 따라 호출할 수도 있으며 비교 연산자(<, >, ? 및 >=)의 사용은 compareTo의 호출로 변환
+- compareTo의 반환 유형은 Int여야 한다.
+
+```kotlin
+class Person(
+        val firstName: String, val lastName: String
+) : Comparable<Person> {
+    override fun compareTo(other: Person): Int {
+        return compareValuesBy(this, other,  // 인자로 받은 함수나 프로퍼티 참조를 차례로 호출하면서 값을 비교
+            Person::lastName, Person::firstName)
+	} 
+}
+
+fun main() {
+    val p1 = Person("Alice", "Smith")
+    val p2 = Person("Bob", "Johnson")
+    println(p1 < p2)
+    // false
+}
+```
+
+## 9.3 컬렉션과 범위에 대해 쓸 수 있는 관례
+
+- 컬렉션 작업에서 인덱스는 많이 활용된다. 인덱스 연산을 지원하는 데 사용되는 규칙을 알아보자
+
+### 9.3.1 인덱스로 원소 접근: get과 set
+
+- Kotlin 에서는 대괄호를 통해 Java 에서 배열에 액세스하는 방식과 유사하게 맵의 요소에 액세스할 수 있다.
+
+`val value = map[key]`
+
+- 동일한 연산자를 사용하여 변경 가능한 맵에서 키의 값을 변경할 수 있다:
+
+`mutableMap[key] = newValue`
+
+액세스 연산자를 사용하여 요소를 읽는 것은 get 연산자 메서드의 호출로 변환되고, 요소를 쓰는 것은 set 메서드의 호출로 변환된다.
+
+```kotlin
+operator fun Point.get(index: Int): Int {  // get 연산자 함수를 정의
+	return when(index) {
+		0 -> x                              // 주어진 인덱스에 해당하는 좌표를 찾음
+		1 -> y
+		else -> throw IndexOutOfBoundsException("Invalid coordinate $index")
+	}
+}
+
+fun main() {
+    val p = Point(10, 20)
+    println(p[1])
+    // 20
+}
+```
+
+- get 의 매개변수는 Int 뿐만 아니라 모든 유형이 될 수 있음
+  - 예를 들어 맵에서 인덱싱 연산자를 사용하는 경우 매개변수 유형은 맵의 키 유형이며 임의의 유형
+- 여러 매개변수를 사용하여 get 메서드를 정의
+  - 예를 들어 2차원 배열이나 행렬을 나타내는 클래스를 구현하는 경우 다음과 같은 메서드를 정의
+  - `get(rowIndex: Int, colIndex: Int) 그리고 matrix[row, col]로 호출` 
+- 여러 개의 오버로드된 컬렉션에 다른 키 유형으로 액세스할 수 있는 경우 다른 매개변수 유형으로 메서드를 가져올 수 있다.
+
+```kotlin
+data class MutablePoint(var x: Int, var y: Int)
+
+operator fun MutablePoint.set(index: Int, value: Int) { // set 이라는 연산자 함수를 정의
+    when(index) {
+    	0 -> x = value                                  // 주어진 인덱스에 해당하는 좌표를 변경
+		1 -> y = value
+		else -> throw IndexOutOfBoundsException("Invalid coordinate $index")
+	} 
+}
+
+fun main() {
+	val p = MutablePoint(10, 20)
+	p[1] = 42
+	println(p)
+	// MutablePoint(x=10, y=42)
+}
+```
+
+### 9.3.2 어떤 객체가 컬렉션에 들어있는지 검사: in 관례
+
+- 컬렉션에서 지원하는 다른 연산자 중 하나는 객체가 컬렉션에 속하는지 확인하는 데 사용되는 in 연산자이다. 
+  - 해당 함수를 contains 라고 한다. 
+- in 연산자를 사용하여 점이 직사각형에 속하는지 여부를 확인할 수 있도록 구현해 보겠다.
+
+```kotlin
+data class Rectangle(val upperLeft: Point, val lowerRight: Point)
+
+operator fun Rectangle.contains(p: Point): Boolean {
+    return p.x in upperLeft.x..<lowerRight.x &&     // 범위를 만들고 x 좌표가 그 범위 안에 있는지 검사한다.
+           p.y in upperLeft.y..<lowerRight.y        // ..< 연산자를 사용해 열린 범위를 만든다.
+}
+
+fun main() {
+    val rect = Rectangle(Point(10, 20), Point(50, 50))
+    println(Point(20, 30) in rect)
+    // true
+    println(Point(5, 5) in rect)
+    // false
+}
+```
+
+### 9.3.3 객체로부터 범위 만들기: rangeTo와 rangeUntil 관례
+
+- 범위를 만들려면 .. 구문을 사용
+- 예를 들어 1..10은 1부터 10까지 모든 수가 들어있는 범위
+- .. 연산자는 rangeTo 함수 호출을 간략하게 표현
+
+```kotlin
+import java.time.LocalDate
+fun main() {
+    val now = LocalDate.now()
+    val vacation = now..now.plusDays(10)    // now(오늘)부터 시작해 10일짜리 범위를 만든다
+    println(now.plusWeeks(1) in vacation)   // 특정 날짜가 날짜 범위 안에 들어가는지 검사한다.
+    // true
+}
+```
+
+- rangeTo 연산자는 산술 연산자보다 우선 순위가 낮다. 그러나 인수를 괄호 로 묶어 혼동을 피하는 것이 좋다:
+
+```kotlin
+fun main() {
+    val n = 9
+    println(0..(n + 1)) // 0..n + 1라고 써도 되지만 괄호를 치면 더 뜻이 명확해진다.
+    // 0..10
+}
+```
+
+### 9.3.4 자신의 타입에 대해 루프 수행: iterator 관례
+
+- Kotlin 의 루프는 범위 검사와 동일한 연산자를 사용 
+- 이 문맥에서는 반복을 수행하는 데 사용된다는 점에서 의미가 다르다.
+- for (x in list) { ... }와 같은문은 Java에서와 마찬가지로 hasNext 및 next 메서드가 반복적으로 호출되는 list.iterator()의 호출로 변환된다.
+
+```kotlin
+operator fun CharSequence.iterator(): CharIterator 
+
+fun main() {
+    for (c in "abc") {
+    }
+}
+```
+
+```kotlin
+operator fun ClosedRange<LocalDate>.iterator(): Iterator<LocalDate> =
+	object : Iterator<LocalDate> {  // 이 객체는 LocalDate 원소에 대한 Iterator를 구현
+    	var current = start
+    	override fun hasNext() = current <= endInclusive // compateTo 를 사용해 날짜를 비교
+	    override fun next(): LocalDate {
+    	    val thisDate = current
+        	current = current.plusDays(1) // 현재 날짜를 1일 뒤로 변경
+        	return thisDate                 // 미리 저장해둔 날짜를 반환
+	} 
+}
+
+fun main() {
+    val newYear = LocalDate.ofYearDay(2042, 1)
+    val daysOff = newYear.minusDays(1)..newYear
+    for (dayOff in daysOff) { println(dayOff) } // daysOff에 대응하는 iterator 함수가 있으면 daysOff에 대해 이터레이션한다.
+    // 2041-12-31
+    // 2042-01-01
+}
+```
+
+## 9.4 component 함수를 사용해 구조 분해 선언 제공
+
+- 이 기능을 사용하면 하나의 복합 값을 언패킹하여 여러 개의 개별 로컬 변수를 초기화하는 데 사용할 수 있다.
+
+```kotlin
+fun main() {
+    val p = Point(10, 20)
+    val (x, y) = p
+    println(x)
+    // 10
+    println(y)
+    // 20
+}
+```
+
+- 내부적으로 구조분해 선언은 다시 한 번 규칙의 원칙을 사용
+- 구조 분헤 선언에서 각 변수를 초기화하기 위해 componentN이라는 함수가 호출되며, 여기서 N은 선언에서 변수의 위치이다.
+
+```kotlin
+class Point(val x: Int, val y: Int) {
+    operator fun component1() = x
+    operator fun component2() = y
+}
+```
+
+- data class 의 경우 모든 프로퍼티에 대해 componentN 함수를 생성
+- 구조 해체 선언 구문을 사용하면 함수를 호출 한 후 값을 쉽게 언패킹하여 사용
+
+```kotlin
+data class NameComponents(val name: String,     // 값을 저장하기 위한 데이터 클래스를 선언
+                          val extension: String)
+                          
+fun splitFilename(fullName: String): NameComponents {
+    val result = fullName.split('.', limit = 2)
+    return NameComponents(result[0], result[1]) // 함수에서 데이터 클래스의 인스턴스를 반환
+}
+
+fun main() {
+    val (name, ext) = splitFilename("example.kt")   // 구조 분해 선언 구문을 사용해 데이터 클래스를 푼다
+    println(name)
+    // example
+    println(ext)
+    // kt
+}
+
+// Better
+fun splitFilename2(fullName: String): NameComponents {
+    val (name, extension) = fullName.split('.', limit = 2)
+    return NameComponents(name, extension)
+}
+```
+
+- componentN 함수를 무한대로 정의할 수는 없고 임의의 수의 항목에 대해 작동
+- 표준 라이브러리에서는 이 구문을 사용하여 컨테이너의 처음 5개의 엘리먼트에 액세스
+- 함수에서 여러값을 반환하는 더 간단한 방법은 표준 라이브러리의 Pair 및 Triple 클래스를 사용하는 것
+  - 이 경우 자체 클래스를 정의하는 것보다 코드가 덜 필요할 수 있지만, Pair 및 Triple은 반환되는 객체에 무엇이 포함되어 있는지 명확하지 않기 때문에 코드에서 중요한 표현력을 포기하게 된다.
+
+### 9.4.1 구조 분해 선언과 루프
+
+- 구조 파괴 선언은 함수의 최상위 문뿐만 아니라 변수를 선언할 수 있는 다른 위치(예 : 루프)에서도 작동한다. 이를 잘 활용하는 한 가지 예는 맵에서 항목을 열거하는 것이다.
+
+```kotlin
+fun printEntries(map: Map<String, String>) {
+    for ((key, value) in map) {     // 루프 변수에 구조 분해 선언을 사용
+        println("$key -> $value")
+    }
+}
+
+fun main() {
+    val map = mapOf("Oracle" to "Java", "JetBrains" to "Kotlin")
+    printEntries(map)
+    // Oracle -> Java
+    // JetBrains -> Kotlin
+}
+```
+
+- 맵 또한 componentN함수를 지원한다.
+
+```kotlin
+for (map.entries의 항목) {
+	val key = entry.component1()
+	val value = entry.component2()
+	// ...
+}
+```
+
+### 9.4.2 _ 문자를 사용해 구조 분해 값 무시
+
+- 많은 컴포넌트가 있는 객체를 구조 분해 선언을 사용할 때 실제로 모든 컴포넌트가 필요하지 않을 수 있다.
+- 아래 예제에서는 Person 클래스를 구조 분해 선언하지만 실제로는 이름과 나이 필드만 사용한다.
+
+```kotlin
+data class Person(
+            val firstName: String,
+            val lastName: String,
+            val age: Int,
+            val city: String,
+)
+        fun introducePerson(p: Person) {
+            val (firstName, lastName, age, city) = p
+            println("This is $firstName, aged $age.")
+}
+```
+
+- 필요하지 않은 필드를 _로 바꾸고 분해하면 필요한 필드만 활용할 수 있다.
+
+```kotlin
+fun introducePerson(p: Person) {
+    val (firstName, _, age) = p
+	println("이것은 $firstName, 나이 $age입니다.")
+}
+```
+
+## 9.5 프로퍼티 접근자 로직 재활용: 위임 프로퍼티
+
+- Kotlin 에서 가장 독특하고 강력한 기능 중 하나인 위임 프로퍼티에 대해 한 가지 더 살펴보겠다. 
+- 이 기능을 사용하면 각 접근자에 로직을 복제하지 않고도 백킹 필드에 값을 저장하는 것보다 더 복잡한 방식으로 작동하는 속성을 쉽게 구현할 수 있다.
+
+### 9.5.1 위임 프로퍼티의 기본 문법과 내부 동작
+
+- 위임된 프로퍼티의 일반적인 구문은 다음과 같다.
+
+```kotlin
+class Foo {
+	var p: Type by Delegate()
+}
+```
+
+Delegate 프로퍼티를 정의하는 클래스의 내부
+
+```kotlin
+class Foo {
+    private val delegate = Delegate()   // 컴파일러가 생성한 도우미 프로퍼티
+    var p: Type                         // p 프로퍼티를 위해 컴파일러가 생성한 접근자는 delegate의 getValue와 getValue 메서드를 호출
+       set(value: Type) = delegate.setValue(/* ... */, value)
+       get() = delegate.getValue(/* ... */)
+}
+
+class Delegate {
+    operator fun getValue(/* ... */) { /* ... */ } // getValue는 게터를 구현하는 로직을 담는다.
+	operator fun setValue(/* ... */, value: Type) { /* ... */ } // setValue 메서드는 세터를 구현하는 로직을 담는다.
+	operator fun provideDelegate(/* ... */): Delegate { /* ... */ } // provideDelegate는 위임 객체를 생성하거나 제공하는 로직을 담는다.
+}
+
+class Foo {
+    var p: Type by Delegate() // by 키워드는 프로퍼티와 위임 객체를 연결한다.(여기서는 Delegate와 새 인스턴스를 프로퍼티와 연결)
+}
+
+fun main() {
+    val foo = Foo() // 위임 프로퍼티가 있는 타입의 객체를 생성하는데, 위임 객체에 provideDelegate가 있으면 그 함수를 호추해 위임 객체를 생성한다.
+    val oldValue = foo.p // foo.p라는 프로퍼티에 접근하면 내부에서 delegate.getValue(...)을 호춣한다.
+    foo.p = newValue // 프로퍼티 값을 변경하는 문장은 내부에서 delegate.setValue(... newValue)를 호출한다.
+}
+```
+
+foo.p를 일반 프로퍼티로 사용하지만, 내부적으로는 델리게이트 유형의 헬퍼 프로퍼티의 메서드가 호출된다.
+
+### 9.5.2 위임 프로퍼티 사용: by lazy()를 사용한 지연 초기화
+
+- 지연 초기화는 개체를 처음 액세스할 때 필요에 따라 객체의 일부를 생성하는 패턴
+- 이는 초기화 프로세스에 상당한 리소스가 소모되고 객체를 사용할 때 데이터가 항상 필요한 것은 아닌 경우에 유용
+
+```kotlin
+class Person(val name: String) {
+    private var _emails: List<Email>? = null
+    val emails: List<Email>
+       get() {
+			if (_emails == null) {
+    			_emails = loadEmails(this)
+			}
+			return _emails!!
+        }
+}
+
+fun main() {
+    val p = Person("Alice")
+    p.emails
+    // Load emails for Alice
+    p.emails
+}
+```
+
+- 값을 저장하는 _emails 라는 프로퍼티가 하나 있고 이에 대한 읽기 액세스 권한을 제공하는 이메일이라는 프로퍼티가 또 하나 있다. 
+- 두 프로퍼티의 유형이 다르기 때문에 두 개의 프로퍼티를 사용해야 한다. 
+- 이메일은 널 가능하지만 이메일은 널이 아니다. 
+- 클래스에 동일한 개념을 나타내는 두 개의 속성이 있는 경우 비공개 속성에는 밑줄(_emails)이 붙고, 공개 속성에는 접두사(_)가 붙지 않는 간단한 규칙에 따라 이름을 지정
+
+Kotlin 은 이것보다 더 나은 솔루션을 제공한다.
+
+```kotlin
+class Person(val name: String) {
+    val emails by lazy { loadEmails(this) }
+}
+```
+
+- lazy 함수는 기본적으로 스레드 안전
+- 필요한 경우 추가 옵션을 지정하여 사용할 잠금을 지정하거나 멀티스레드 환경에서 클래스가 사용되지 않는 경우 동기화를 완전히 우회
+
+### 9.5.3 위임 프로퍼티 구현
+
+- 위임된 프로퍼티가 어떻게 구현되는지 알아보기 위해 객체의 프로퍼티가 변경될 때 리스너에게 알리는 작업을 예로 들어 보겠다.
+- 이런 프로퍼티를 일반적으로 `observable` 
+
+코틀린에서 이를 구현하는 방법을 알아보자.
+아래의 Person 객체는 나이나 급여가 변경되면 관찰자에게 알린다.
+
+```kotlin
+fun interface Observer {
+  fun onChange(name: String, oldValue: Any?, newValue: Any?)
+}
+
+open class Observable {
+  val observers = mutableListOf<Observer>()
+
+  fun notifyObservers(propName: String, oldValue: Any?, newValue: Any?) {
+    for (obs in observers) {
+      obs.onChange(propName, oldValue, newValue)
+    }
+  }
+}
+
+class Person(val name: String, age: Int, salary: Int): Observable() {
+    var age: Int = age
+        set(newValue) {
+	        val oldValue = field
+    	    field = newValue
+        	notifyObservers(
+            	"age", oldValue, newValue
+        	)
+		}
+
+	var salary: Int = salary
+    	set(newValue) {
+            val oldValue = field
+            field = newValue        // 뒷받침하는 필드에 접근할 때 field 식별자를 사용
+            notifyObservers(        // 프로퍼티 변경을 옵저버들에게 통지
+                "salary", oldValue, newValue
+            )
+        }
+}
+
+fun main() {
+    val p = Person("Seb", 28, 1000)
+    p.observers += Observer { propName, oldValue, newValue ->
+        println(
+            """
+        Property $propName changed from $oldValue to $newValue로
+		""".trimIndent()
+        )
+    }
+	p.age = 29
+	// Property age changed 28 to 29!
+	p.salary = 1500
+	// Property salary changed from 1000 to 1500!
+}
+```
+
+위의 코드의 세터에는 반복되는 코드가 꽤 많이 있다. 프로퍼티의 값을 저장하고 필요한 알림을 실행하는 클래스를 추출해 보겠다.
+
+```kotlin
+class ObservableProperty(
+    val propName: String,
+    var propValue: Int,
+	val observable: Observable 
+) {
+    
+    fun getValue(): Int = propValue
+  
+  	fun setValue(newValue: Int) {
+        val oldValue = propValue
+        propValue = newValue
+        observable.notifyObservers(propName, oldValue, newValue)
+	} 
+}
+
+class Person(val name: String, age: Int, salary: Int): Observable() {
+    val _age = ObservableProperty("age", age, this)
+    var age: Int
+        get() = _age.getValue()
+        set(newValue) {
+            _age.setValue(newValue)
+        }
+    
+    val _salary = ObservableProperty("salary", salary, this)
+    var salary: Int
+		get() = _salary.getValue()
+		set(newValue) {
+        	_salary.setValue(newValue)
+		}
+}
+```
+
+Kotlin 에서는 위와같은 위임속성 기능을 이미 제공하고, 그 형식은 실질적으로 아래와 비슷하다.
+
+```kotlin
+import kotlin.reflect.KProperty
+class ObservableProperty(var propValue: Int, val observable: Observable) {
+  operator fun getValue(thisRef: Any?, prop: KProperty<*>): Int = propValue
+  operator fun setValue(thisRef: Any?, prop: KProperty<*>, newValue: Int) {
+      val oldValue = propValue
+      propValue = newValue
+      observable.notifyObservers(prop.name, oldValue, newValue)
+	}
+}
+```
+
+프로퍼티는 KProperty 타입의 객체로 표현된다.
+
+```kotlin
+class Person(val name: String, age: Int, salary: Int) : observable() { 
+	var age by observableProperty(age, this)
+	var salary by observableProperty(salary, this)
+}
+```
+
+- 코드가 엄청나게 짧아졌음
+- 이런 상황이 필요할 때 관찰 가능한 속성 로직을 직접 구현하는 대신 Kotlin 표준 라이브러리를 사용할 수 있음
+
+### 9.5.4 위임 프로퍼티는 커스텀 접근자가 있는 감춰진 프로퍼티로 변환된다
+
+```kotlin
+class C {
+    var prop: Type by MyDelegate()
+}
+val c = C()
+```
+
+- MyDelegate 의 인스턴스는 다음과 같은 숨겨진 프로퍼티에 저장된다. 아 객체를 <delegate> 라고 한다. 
+- 컴파일러는 프로퍼티를 표현하기 위해 KProperty 유형의 객체도 사용한다. 이 객체를 <property> 라고 한다.
+
+컴파일러는 다음 코드를 생성한다.
+
+```kotlin
+class C {
+    private val <delegate> = MyDelegate()
+	var prop: Type
+		get() = <delegate>.getValue(this, <property>)
+		set(value: Type) = <delegate>.setValue(this, <property>, value)
+}
+```
+
+### 9.5.5 맵에 위임해서 동적으로 애트리뷰트 접근
+
+- 자신의 프로퍼티를 동적으로 정의할 수 있는 객체를 만들 때 위임 프로퍼티를 활용
+
+```kotlin
+class Person {
+    private val _attributes = mutableMapOf<String, String>()
+    fun setAttribute(attrName: String, value: String) {
+        _attributes[attrName] = value
+	}
+    
+    var name: String
+        get() = _attributes["name"]!!
+        set(value) {
+            _attributes["name"] = value
+        }
+}
+
+fun main() {
+    val p = Person()
+    val data = mapOf("name" to "Seb", "company" to "JetBrains")
+    for ((attrName, value) in data)
+       p.setAttribute(attrName, value)
+    println(p.name)
+    // Seb
+    p.name = "Sebastian"
+    println(p.name)
+    // Sebastian
+}
+```
+
+### 9.5.6 실전 프레임워크가 위임 프로퍼티를 활용하는 방법
+
+```kotlin
+object Users : IdTable() {
+    val name = varchar("name", length = 50).index()
+    val age = integer("age")
+}
+
+class User(id: EntityID) : Entity(id) {
+    var name: String by Users.name
+    var age: Int by Users.age
+}
+```
+
+- 프레임워크를 사용하면 프로퍼티에 액세스하면 Entity 클래스의 매핑에서 해당 값을 자동으로 검색하고 이를 수정하면 객체를 가져와서 필요할 때 데이터베이스에 저장할 수 있으므로 특히 편리
+- Kotlin 코드에 user.age += 1을 작성하면 데이터 베이스의 해당 엔티티가 자동으로 업데이트
+- 이제 이러한 API가 포함된 프레임워크가 어떻게 구현되는지 충분히 이해하셨을 것입니다. 각 엔티티 속성(이름, 나이)은 열 개체(Users.name, Users.age)를 델리게이트 로 사용하여 위임된 속성으로 구현된다.


### PR DESCRIPTION
## 간략한 내용 정리

- 구조 분해는 순서가 있는 함수 호출
  - 데이터 클래스 (data class)에서는 자동 생성
  - 일반 클래스에서도 직접 componentN을 정의하면 가능
  - 구조 분해에서 필요 없는 값은 _(언더스코어) 로 무시
- 위임 프로퍼티는 코드 재사용성과 가독성을 극대화하면서, 프로그램의 일관성을 높이는 기능

## 읽고 느낀 점

구조 분해 사용은 순서등 조심해야될 부분이 있어 보여서 작은 객체안에서 사용하면 좋을것 같고,
위임 프로퍼티의 lazy, observable 등 실무에서 사용해볼 수 있는 부분들을 알아가서 잘 사용해보면 좋을것 같습니다!

## 의문, 고민, 같이 이야기하고 싶은 부분

`componentN` 관련해서 gpt에게 물어봤어요.

왜 componentN 이름이 고정되어야 할까?

- 구조 분해 선언은 "컴파일러 규칙"에 따라 동작합니다.
- 코틀린 컴파일러는 구조 분해할 때 "N번째 변수는 N번째 componentN() 메서드를 호출"하도록 하드코딩되어 있어요.

즉,

```kotlin
val (a, b) = something
```

이렇게 구조 분해를 쓰면, 컴파일러는 무조건 아래와 같이 변환해요.

```kotlin
val a = something.component1()
val b = something.component2()
```

✅ 자유로운 이름을 허용하면 컴파일러가 어떤 메서드를 호출해야 할지 예측할 수 없기 때문에, 이름은 componentN으로 고정되어야 합니다.
(이건 언어 설계상 결정된 규칙이에요.)

componentN은 몇 개까지 지원될까?

공식 문서에 따르면,
Kotlin 컴파일러는 component1부터 component32까지 기본 지원합니다.

✅ 즉, 최대 32개의 componentN 함수를 사용할 수 있습니다.

만약 data class에서 33개 이상의 프로퍼티를 선언해도, 컴파일은 가능하지만 구조 분해는 32개까지만 사용할 수 있어요.