### PR TITLE
docs: 9장 연산자 오버로딩과 다른 관례

### DIFF
--- a/전종혁/09.연산자오버로딩과다른관례.md
+++ b/전종혁/09.연산자오버로딩과다른관례.md
@@ -1,0 +1,132 @@
+# PART_9 연산자 오버로딩과 다른 관례
+<br><br>
+<hr>
+
+## 다루는 내용
+
+>- 연산자 오버로딩
+>- 관례: 여러 연산을 지원하기 위해 특별한 이름이 붙은 메서드
+>- 위임 프로퍼티
+
+<hr>
+<br><br>
+
+### 9.1 산술 연산자를 오버로드해서 임의의 클래스에 대한 연산을 더 편리하게 만들기
+- 코틀린에서는 BigInteger 와 같은 클래스를 다룰때 add 메서드 대신 + 사용이 가능하다
+
+### 9.1.1 plus, times, divide 등: 이항 산술 연산 오버로딩
+```kotlin
+data class Point(val x: Int, val y: Int) {
+    operator fun plus(other: Point): Point {
+        return Point(x + other.x, y+other.y)
+    }
+}
+```
+- 연산자를 오버로딩하는 함수 앞에는 반드시 operator 가 있어야 한다.
+- 코틀린 연산자가 자동으로 교환법칙을 지원하지 않는다.
+- 비트 연산자에 대해 특별한 연산자 함수를 사용하지 않는다.
+
+### 9.1.2 연산을 적용한 다음에 그 결과를 바로 대입: 복합 대입 연산자 오버로딩
+- 복합 대입 연산자도 자동으로 함께 지원한다.
+- 반환 타입이 Unit 인 plusAssign 함수를 정의하면서 operator 로 표시하면 코틀린은 += 연산자에 그 함수를 사용한다.
+
+### 9.1.3 피연산자가 1개뿐인 연산자: 단항 연산자 오버로딩
+```kotlin
+operator fun Point.unaryMinus(): Point {
+    return Point(-x,-y)
+}
+```
+
+### 9.2 비교 연산자를 오버로딩해서 객체들 사이의 관계를 쉽게 검사
+### 9.2.1 동등성 연산자: equals
+- 양쪽인자가 모두 null 인경우 true 로 반환된다.
+- equals 는 Any 에 정의된 메서드이므로 override 가 필요하다.
+- Any 에서 상속받은 equals 가 확장 함수보다 우선순위가 높기 때문에 equals 를 확장 함수로 정의할 수 없다.
+
+### 9.2.2 순서 연산자: compareTo (<, >, <= >=)
+- 처음에는 성능에 신경 쓰지 말고 이해하기 쉽고 간결하게 코드를 작성하고, 나중에 그 코드가 자주 호출됨에 따라 성능이 문제가 되면 성능을 개선하라
+
+### 9.3 컬렉션과 범위에 대해 쓸 수 있는 관례
+### 9.3.1 인덱스로 원소 접근: get 과 set
+```kotlin
+operator fun Point.get(index: Int): Int {
+    return when(index) {
+        0 -> x
+        1 -> y
+        else ->
+            throw IndexOutOfBoundsException("Invalid coordinate $index")
+    }
+}
+```
+- 2차원 행렬이나 배열을 표현하는 클래스에 get 을 정의하면 matrix[row, col] 로 그 메서드를 호출할 수 있다.
+
+### 9.3.2 어떤 객체가 컬렉션에 들어있는지 검사: in 관례
+- in 은 객체가 컬렉션에 들어있는지 검사한다. 이때 대응하는 함수는 contains 다.
+- ..< 연산자: 열린 범위
+
+### 9.3.3 객체로부터 범위 만들기: rangeTo와 rangeUntil 관례
+- .. 연산자는 rangeTo 함수 호출을 간략하게 표현하는 방법이다.
+- rangeTo 함수는 Comparable 에 대한 확장 함수다.
+- 0..n.forEach 와 같이 사용할 수 없고, 괄호로 둘러싸야함. (0..n).forEach
+
+### 9.3.4 자신의 타입에 대해 루프 수행: iterator 관례
+- Iterator<LocalDate> 를 반환해야 하므로 hasNext(), next() 를 override 해야 한다.
+
+### 9.4 component 함수를 사용해 구조 분해 선언 제공
+- 구조 분해 선언: 복합적인 값을 분해해서 별도의 여러 지역 변수를 한꺼번에 초기화할 수 있다.
+- val (x,y) = p
+- 표준라이브러리의 Pair 나 Triple 클래스는 그 안에 담겨있는 원소의 의미를 말해주지 않으므로 코드의 귀중한 표현력을 잃게 된다.
+
+### 9.4.1 구조 분해 선언과 루프
+- for ((key, value) in map) 와 같이 사용 가능하다.
+- map.forEach {(key, value) -> }
+
+### 9.4.2 _ 문자를 사용해 구조 분해 값 무시
+- val (firstName, _, age) = p 와 같이 필요 없는 값은 _ 문자를 사용해 무시할 수 있다.
+- 필드 순서로 대입되기 때문에 단점이 명확하다.
+
+### 9.5 프로퍼티 접근자 로직 재활용: 위임 프로퍼티
+### 9.5.1 위임 프로퍼티의 기본 문법과 내부 동작
+- var p: Type by Delegate()
+- p 프로퍼티는 접근자 로직을 다른 객체에 위임한다.
+
+### 9.5.2 위임 프로퍼티 사용: by lazy() 를 사용한 지연 초기화
+- 지연 초기화는 객체의 일부분을 초기화하지 않고 남겨뒀다가 실제로 그 부분의 값이 필요한 경우 초기화할 때 흔히 쓰이는 패턴이다.
+- 비공개 프로퍼티에는 _를 붙이고, 공개 프로퍼티에는 아무것도 붙이지 않는 기법 뒷받침하는 프로퍼티
+- lazy 함수: 위임 프로퍼티를 통해 지연 초기화
+
+### 9.5.3 위임 프로퍼티 구현
+- Observable: 객체의 상태가 변하면 자동으로 프로퍼티가 바뀌는 방식
+```kotlin
+import kotlin.reflect.KProperty
+
+class ObservableProperty(var propValue: Int, val observable: Observable) {
+    operator fun getValue(thisRef: Any?, prop: KProperty<*>): Int = propValue
+    operator fun setValue(thisRef: Any?, prop: KProperty<*>, newValue: Int) {
+        val oldValue = propValue
+        propValue = newValue
+        observable.notifyObservers(prop.name, oldValue, newValue)
+    }
+}
+```
+
+### 9.5.4 위임 프로퍼티는 커스텀 접근자가 있는 감춰진 프로퍼티로 변환한다.
+- 컴파일러는 모든 프로퍼티 접근자 안에 getValue 와 setValue 호출 코드를 생성해준다.
+
+### 9.5.5 맵에 위임해서 동적으로 애트리뷰트 접근
+- 확장 가능한 객체: 자신의 프로퍼티를 동적으로 정의할 수 있는 객체를 만들 때 위임 프로퍼티를 활용
+- var name: String by _attributes <- 위임 프로퍼티를 맵을 사용한다.
+
+### 9.5.6 실전 프레임워크가 위임 프로퍼티를 활용하는 방법
+- 위임 프로퍼티를 사용해 데이터베이스 칼럼에 접근 가능하다.
+```kotlin
+object Users : IdTable() {
+    val name = varchar("name", length = 50).index()
+    val age = integer("age")
+}
+
+class User(id: EntityID) : Entity(id) {
+    var name: String by Users.name
+    var age: Int by Users.age
+}
+```


### PR DESCRIPTION
## 읽고 느낀 점
- java 에서 a.메서드(b) 와 같이 사용하는 경우가 많은데 특히 LocalDateTime 을 사용할 때 isAfter(), isBefore() isEquals 를 여러번 사용하면서 가독성이 떨어지는 경우가 많았는데 유용할 것 같습니다.
